### PR TITLE
Strip trailing newline from vedit stdout output.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -153,9 +153,8 @@ require 'mixlib/shellout'
 vedit = Mixlib::ShellOut.new("curl -s https://extdist.wmflabs.org/dist/extensions/ | grep -Eo VisualE.*tar.gz | awk -F'>' '{print $2}' | grep 1_27")
 vedit.run_command
 
-
 ark 'VisualEditor' do
-  url "https://extdist.wmflabs.org/dist/extensions/#{vedit.stdout}"
+  url "https://extdist.wmflabs.org/dist/extensions/#{vedit.stdout.tr("\n", "")}"
   path '/var/www/mediawiki/extensions/'
   owner 'nginx'
   action :put


### PR DESCRIPTION
The trailing newline causes the cookbook to break on Ubuntu 16.04.1.
Using Chef client 12.15.19 and Ruby 2.3.
